### PR TITLE
Adding newline to allow correct script execution

### DIFF
--- a/docs/operate-and-deploy/installation/install-ksqldb-with-docker.md
+++ b/docs/operate-and-deploy/installation/install-ksqldb-with-docker.md
@@ -521,7 +521,7 @@ ksql-cli:
         sleep 5
       done
       echo -e "\n\n-> Running SQL commands\n"
-      cat /data/scripts/my-ksql-script.sql <(echo 'EXIT')| ksql http://<ksql-server-ip>:8088
+      cat /data/scripts/my-ksql-script.sql <(echo -e '\nEXIT')| ksql http://<ksql-server-ip>:8088
       echo -e "\n\n-> Sleeping…\n"
       sleep infinity
 ```


### PR DESCRIPTION
Adding a newline to avoid the need to remember to leave an empty line at the end of a KSQL script to allow for EXIT to be appended after the script executes rather than at the end of the last line of the script.

### Description 
_What behavior do you want to change, why, how does your patch achieve the changes?_
Currently, the Docker Compose configuration for executing scripts via the ksqlDB CLI requires that I leave an empty line at the end of KSQL scripts in order for KSQL scripts to run correctly.  I don't always remember, and script execution fails.  I realized that adding a newline return character before EXIT removes this issue, and sure enough, it does!  I'm creating this PR so I don't have to remember in the future and so others can leverage this minor productivity improvement as well.

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._
Tested locally - scripts run successfully without the need for leaving a blank last line.

### Reviewer checklist
- [x] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

